### PR TITLE
Add partial support for labels

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,6 +111,6 @@ linters:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.44.x
+  golangci-lint-version: 1.45.x
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,15 @@ lint:
 
 .PHONY: dependencies
 dependencies: ## Install dependencies needed to work with this repo
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.44.0
+	@go install github.com/cespare/reflex@latest
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	@go mod tidy
+
+.PHONY: unit_test
+unit_test:
+	@-go test -trimpath -failfast ./...
+
+
+.PHONY: unit_test_watch
+unit_test_watch: unit_test
+	reflex --shutdown-timeout=500ms --sequential=false -d none -r "(\.go$$)|(go.mod)|(\.sql$$)" make unit_test

--- a/README.md
+++ b/README.md
@@ -7,21 +7,30 @@ Compatible with YAML through https://github.com/go-yaml/yaml
 ## Usage
 
 ```go
-a := vergo.New(1,2,3)
-b := vergo.ParseSemver("v1.2.4")
+a := vergo.New(1, 2, 3, "")
+b, _ := vergo.ParseSemver("v1.2.4")
 
 fmt.Println(a) // 1.2.3
 fmt.Println(b) // v1.2.4 preserves the versioning
 
 fmt.Println(a.Before(b)) // true
-fmt.Println(a.After(b)) // false
+fmt.Println(a.After(b))  // false
 
-a.Bump(vergo.Major)
+a.Bump(vergo.BumpMajor)
 
 fmt.Println(a) // 2.0.0
 
 fmt.Println(a.Before(b)) // false
-fmt.Println(a.After(b)) // true
+fmt.Println(a.After(b))  // true
+
+c := vergo.New(1, 0, 0, "rc1")         // or -rc1
+_ = c.Bump(vergo.BumpReleaseCandidate) // will error if it is not rc<NUMBER>
+fmt.Println(c)                         // 2.0.0-rc2 nil
 ```
 
 Run it on https://go.dev/play/p/E6EyO2LfjtC
+
+## Semver labels
+
+Vergo has limited support for semver with labels (e.g. `v1.0.0-rc1`).
+It can parse any sort of label but can only apply a bump to labels in the form of `rc<NUMBER>`.

--- a/errors.go
+++ b/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrMalformedMajor = errors.Wrap(ErrMalformed, "major")
 	ErrMalformedMinor = errors.Wrap(ErrMalformed, "minor")
 	ErrMalformedPatch = errors.Wrap(ErrMalformed, "patch")
+	ErrMalformedLabel = errors.Wrap(ErrMalformed, "only labels in the form of rc<NUMBER> can be bumped")
 )


### PR DESCRIPTION
For now this can parse any label.
Bump only works for labels in the form of `rc<NUMBER>`

Closes #1 